### PR TITLE
Update Ax to 1.0.0 and Add Missing Packages

### DIFF
--- a/bic-mobo.yml
+++ b/bic-mobo.yml
@@ -6,9 +6,9 @@ dependencies:
   - pip
   - pip:
     - ax-platform==1.0.0
-    - torch==2.1.0
+    - torch
     - pandas
-    - numpy==1.26.4
+    - numpy
     - matplotlib
     - seaborn
     - wandb


### PR DESCRIPTION
This PR updates the Ax version to 1.0.0 and adds packages used in `run-analyses.py` to the conda environment file.