### PR TITLE
Add interfaces to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import setuptools
 setuptools.setup(
     name     = 'bic-mobo',
     version  = '0.0.0',
-    packages = ['EICMOBOTestTools', 'AID2ETestTools', 'objectives']
+    packages = ['EICMOBOTestTools', 'AID2ETestTools', 'objectives', 'interfaces']
 )
 
 # end =========================================================================


### PR DESCRIPTION
Missed this when implementing the `interfaces` package.