### PR TITLE
Add cost objective

### DIFF
--- a/interfaces/RunObjectives.py
+++ b/interfaces/RunObjectives.py
@@ -56,10 +56,20 @@ def RunObjectives(tag = None, **kwargs):
     for obj, file in oFiles.items():
         oTxt = file.replace(".root", ".txt")
         oVal = None
-        with open(oTxt, 'r') as out:
-            oDat = out.readlines()
-            oVal = float(oDat[0])
-        objectives[obj] = oVal
+        if os.path.isfile(oTxt):
+            with open(oTxt, 'r') as out:
+                oDat = out.readlines()
+                oVal = float(oDat[0])
+            objectives[obj] = oVal
+
+    # if needed, calculate cost
+    cfg_obj = emt.ReadJsonFile(obj_path)
+    if "Cost" in cfg_obj["objectives"]:
+        cost = 1
+        for key, value in kwargs.items():
+            if "enable_staves_" in key:
+                cost += int(value)
+        objectives["Cost"] = cost
 
     # return dictionary of objectives
     return objectives


### PR DESCRIPTION
This PR implements wiring to calculate the "cost" objective, i.e. the no. of AstroPix staves used. Activating this objective is done by adding the minimal set of info to `objectives.config`, e.g.
```json
{
    "_comment"   : "Configure objectives to optimize for",
    "objectives" : {
        "ElectronEnergyResolution" : {
            "input"     : "single_electron",
            "path"      : "/home/dereka/aid2e/dev/ForBICStage3B/BIC-MOBO/objectives",
            "exec"      : "BICEnergyResolution.py",
            "rule"      : "python <EXEC> -i <RECO> -o <OUTPUT> -p 11",
            "stage"     : "ana",
            "goal"      : "minimize",
            "threshold" : 1.0
        },
        "Cost" : {
            "stage"     : "post",
            "goal"      : "minimize",
            "threshold" : 6
        }
    }
}
```

Note that the `stage` can be _anything_ other than `ana`; `post` here is intended to convey that this objective is calculated _after_ everything else.