### PR TITLE
Add `$BIC_MOBO` to Ax output path

### DIFF
--- a/configuration/problem.config
+++ b/configuration/problem.config
@@ -2,7 +2,7 @@
     "_comment"         : "Configures problem for Ax",
     "name"             : "BIC Optimization",
     "problem_name"     : "bic_mobo",
-    "OUTPUT_DIR"       : "out",
+    "OUTPUT_DIR"       : "$BIC_MOBO/out",
     "n_sobol"          : 2,
     "min_sobol"        : 2,
     "max_parallel_gen" : 1,


### PR DESCRIPTION
This PR ensures Ax output gets placed in the BIC-MOBO installation by prepending the default `OUTPUT_DIR` value with `$BIC_MOBO/`.